### PR TITLE
Use sets rather than the global redis key namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :test do
   unless ENV['TRAVIS']
-    gem 'byebug', '~> 10', platform: :mri, require: false
-    gem 'pry', '~> 0', platform: :mri, require: false
-    gem 'pry-byebug', '~> 3', platform: :mri, require: false
+    gem 'byebug', '~> 11.3'
+    gem 'pry', '~> 0.13.2'
+    gem 'minitest-focus', '~> 1.2.1'
   end
   gem 'rubocop', '~> 0.60.0'
   gem 'simplecov', '~> 0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :test do
   unless ENV['TRAVIS']
-    gem 'byebug', '~> 11.3'
-    gem 'pry', '~> 0.13.2'
-    gem 'minitest-focus', '~> 1.2.1'
+    gem 'byebug', '~> 10'
   end
   gem 'rubocop', '~> 0.60.0'
   gem 'simplecov', '~> 0', require: false

--- a/README.md
+++ b/README.md
@@ -33,13 +33,11 @@ gem 'resque-unique_in_queue'
 
 ## Usage
 
-`resque-unique_in_queue` utilizes 3 class instance variables that can be set
-in your Jobs, in addition to the standard `@queue`.  Here they are, with their
+`resque-unique_in_queue` utilizes one class instance variables that can be set
+in your Jobs, in addition to the standard `@queue`.  Here it is, with its
 default values:
 
 ```ruby
-@lock_after_execution_period = 0
-@ttl = -1
 @unique_in_queue_key_base = 'r-uiq'.freeze
 ```
 
@@ -81,33 +79,8 @@ Resque.enqueued_in? :dogs, UpdateCat, 1
 => false
 ```
 
-### Options
-
-#### `lock_after_execution_period`
-
-By default, lock_after_execution_period is 0 and `enqueued?` becomes false as soon as the job
-is being worked on.
-
-The `lock_after_execution_period` setting can be used to delay when the unique job key is deleted
-(i.e. when `enqueued?` becomes `false`). For example, if you have a long-running unique job that
-takes around 10 seconds, and you don't want to requeue another job until you are sure it is done,
-you could set `lock_after_execution_period = 20`. Or if you never want to run a long running
-job more than once per minute, set `lock_after_execution_period = 60`.
-
-```ruby
-class UpdateCat
-  include Resque::Plugins::UniqueInQueue
-  @queue = :cats
-  @lock_after_execution_period = 20
-
-  def self.perform(cat_id)
-    # do something
-  end
-end
-```
-
 #### Oops, I have stale Queue Time uniqueness keys...
- 
+
 Preventing jobs with matching signatures from being queued, and they never get
 dequeued because there is no actual corresponding job to dequeue.
 
@@ -166,7 +139,7 @@ spec.add_dependency 'resque-unique_in_queue', '~> 1.0'
 * Copyright (c) 2012 Jonathan R. Wallace
 * Copyright (c) 2017 - 2018 [Peter H. Boling][peterboling] of [Rails Bling][railsbling]
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 [license]: LICENSE
 [semver]: http://semver.org/

--- a/lib/resque/plugins/unique_in_queue.rb
+++ b/lib/resque/plugins/unique_in_queue.rb
@@ -19,7 +19,11 @@ module Resque
 
       module ClassMethods
         def unique_in_queue_redis_key(queue, item)
-          "#{unique_in_queue_key_base}:queue:#{queue}:job:#{Resque::UniqueInQueue::Queue.const_for(item).redis_key(item)}"
+          "#{unique_in_queue_key_base}:queue:#{queue}:job"
+        end
+
+        def unique_in_queue_redis_value(queue, item)
+          Resque::UniqueInQueue::Queue.const_for(item).redis_key(item)
         end
 
         # Payload is what Resque stored for this job along with the job's class name:

--- a/lib/resque/plugins/unique_in_queue.rb
+++ b/lib/resque/plugins/unique_in_queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resque
   module Plugins
     # If you want your job to support uniqueness at enqueue-time, simply include

--- a/lib/resque/plugins/unique_in_queue.rb
+++ b/lib/resque/plugins/unique_in_queue.rb
@@ -39,33 +39,6 @@ module Resque
           Digest::MD5.hexdigest Resque.encode(class: job, args: args)
         end
 
-        # The default ttl of a persisting key is 0, i.e. immediately deleted.
-        # Set lock_after_execution_period to block the execution
-        # of the job for a certain amount of time (in seconds).
-        # For example:
-        #
-        # class FooJob
-        #   include Resque::Plugins::UniqueInQueue
-        #   @lock_after_execution_period = 40
-        # end
-        def lock_after_execution_period
-          instance_variable_get(:@lock_after_execution_period) ||
-              instance_variable_set(:lock_after_execution_period, Resque::UniqueInQueue.configuration&.lock_after_execution_period)
-        end
-
-        # The default ttl of a locking key is -1 (forever).
-        # To expire the lock after a certain amount of time, set a ttl (in seconds).
-        # For example:
-        #
-        # class FooJob
-        #   include Resque::Plugins::UniqueInQueue
-        #   @ttl = 40
-        # end
-        def ttl
-          instance_variable_get(:@ttl) ||
-              instance_variable_set(:ttl, Resque::UniqueInQueue.configuration&.ttl)
-        end
-
         # Should not generally be overridden per each class because it wouldn't
         #   make sense.
         # It wouldn't be able to determine or enforce uniqueness across queues,

--- a/lib/resque/unique_in_queue/configuration.rb
+++ b/lib/resque/unique_in_queue/configuration.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'logger'
+
 module Resque
   module UniqueInQueue
     class Configuration

--- a/lib/resque/unique_in_queue/configuration.rb
+++ b/lib/resque/unique_in_queue/configuration.rb
@@ -2,26 +2,20 @@ require 'logger'
 module Resque
   module UniqueInQueue
     class Configuration
-      DEFAULT_LOCK_AFTER_EXECUTION_PERIOD = 0
-      DEFAULT_TTL = -1
       DEFAULT_UNIQUE_IN_QUEUE_KEY_BASE = 'r-uiq'.freeze
       DEFAULT_LOG_LEVEL = :debug
 
       include Singleton
 
       attr_accessor :debug_mode,
-                    :lock_after_execution_period,
                     :log_level,
                     :logger,
-                    :ttl,
                     :unique_in_queue_key_base
 
       def initialize
         debug_mode_from_env
-        @lock_after_execution_period = DEFAULT_LOCK_AFTER_EXECUTION_PERIOD
         @log_level = DEFAULT_LOG_LEVEL
         @logger = nil
-        @ttl = DEFAULT_TTL
         @unique_in_queue_key_base = DEFAULT_UNIQUE_IN_QUEUE_KEY_BASE
         if @debug_mode
           # Make sure there is a logger when in debug_mode
@@ -32,10 +26,8 @@ module Resque
       def to_hash
         {
             debug_mode: debug_mode,
-            lock_after_execution_period: lock_after_execution_period,
             log_level: log_level,
             logger: logger,
-            ttl: ttl,
             unique_in_queue_key_base: unique_in_queue_key_base
         }
       end

--- a/lib/resque/unique_in_queue/queue.rb
+++ b/lib/resque/unique_in_queue/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resque
   module UniqueInQueue
     module Queue

--- a/lib/resque/unique_in_queue/version.rb
+++ b/lib/resque/unique_in_queue/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module UniqueInQueue
-    VERSION = '2.0.1'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end

--- a/test/fake_jobs.rb
+++ b/test/fake_jobs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FakeJob
   @queue = :normal
 end

--- a/test/fake_jobs.rb
+++ b/test/fake_jobs.rb
@@ -18,18 +18,3 @@ class FailingUniqueInQueue
   end
 end
 
-class UniqueInQueueWithTtl
-  include Resque::Plugins::UniqueInQueue
-  @queue = :unique_with_ttl
-  @ttl = 300
-
-  def self.perform(*_); end
-end
-
-class UniqueInQueueWithLock
-  include Resque::Plugins::UniqueInQueue
-  @queue = :unique_with_lock
-  @lock_after_execution_period = 150
-
-  def self.perform(*_); end
-end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -45,12 +45,11 @@ class JobTest < MiniTest::Spec
     assert_equal 1, Resque.size(:unique)
   end
 
-  focus
   it 'mark jobs as unqueued when Resque processes them' do
     Resque.enqueue FakeUniqueInQueue, 'foo'
     assert Resque.enqueued?(FakeUniqueInQueue, 'foo')
     Resque.reserve(:unique)
-    assert !Resque.enqueued?(FakeUniqueInQueue, 'foo')
+    refute Resque.enqueued?(FakeUniqueInQueue, 'foo')
   end
 
   it 'mark jobs as unqueued when they raise an exception' do

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -81,6 +81,9 @@ class JobTest < MiniTest::Spec
     Resque.enqueue FakeUniqueInQueue, 'foo'
     Resque.enqueue FailingUniqueInQueue, 'foo'
     Resque.remove_queue(:unique)
+    refute Resque.enqueued?(FakeUniqueInQueue, 'foo')
+    refute Resque.enqueued?(FailingUniqueInQueue, 'foo')
+
     Resque.enqueue(FakeUniqueInQueue, 'foo')
     assert_equal 1, Resque.size(:unique)
   end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -87,31 +87,4 @@ class JobTest < MiniTest::Spec
     Resque.enqueue(FakeUniqueInQueue, 'foo')
     assert_equal 1, Resque.size(:unique)
   end
-
-  it 'honor ttl in the redis key' do
-    Resque.enqueue UniqueInQueueWithTtl
-    assert Resque.enqueued?(UniqueInQueueWithTtl)
-    keys = Resque.redis.keys 'r-uiq:queue:unique_with_ttl:job'
-    assert_equal 1, keys.length
-    assert_in_delta UniqueInQueueWithTtl.ttl, Resque.redis.ttl(keys.first), 2
-  end
-
-  it 'prevents duplicates within lock_after_execution_period' do
-    Resque.enqueue UniqueInQueueWithLock, 'foo'
-    Resque.enqueue UniqueInQueueWithLock, 'foo'
-    assert_equal 1, Resque.size(:unique_with_lock)
-    Resque.reserve(:unique_with_lock)
-    assert_equal 0, Resque.size(:unique_with_lock)
-    Resque.enqueue UniqueInQueueWithLock, 'foo'
-    assert_equal 0, Resque.size(:unique_with_lock)
-  end
-
-  it 'honor lock_after_execution_period in the redis key' do
-    Resque.enqueue UniqueInQueueWithLock
-    Resque.reserve(:unique_with_lock)
-    keys = Resque.redis.keys 'r-uiq:queue:unique_with_lock:job'
-    assert_equal 1, keys.length
-    assert_in_delta UniqueInQueueWithLock.lock_after_execution_period,
-                    Resque.redis.ttl(keys.first), 2
-  end
 end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class JobTest < MiniTest::Spec
@@ -8,6 +10,7 @@ class JobTest < MiniTest::Spec
   it 'enqueue identical jobs once' do
     Resque.enqueue FakeUniqueInQueue, 'x'
     Resque.enqueue FakeUniqueInQueue, 'x'
+    byebug
     assert_equal 1, Resque.size(:unique)
   end
 

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -14,42 +14,4 @@ class QueueTest < MiniTest::Spec
       assert Resque::UniqueInQueue::Queue.is_unique?(class: 'FakeUniqueInQueue')
     end
   end
-
-  describe '.item_ttl' do
-    it 'is -1 for non-unique job' do
-      assert_equal(-1, Resque::UniqueInQueue::Queue.item_ttl(class: 'FakeJob'))
-    end
-
-    it 'is -1 for invalid job class' do
-      assert_equal(-1, Resque::UniqueInQueue::Queue.item_ttl(class: 'InvalidJob'))
-    end
-
-    it 'is -1 for unique job' do
-      assert_equal(-1, Resque::UniqueInQueue::Queue.item_ttl(class: 'FakeUniqueInQueue'))
-    end
-
-    it 'is job TTL' do
-      assert_equal 300, UniqueInQueueWithTtl.ttl
-      assert_equal 300, Resque::UniqueInQueue::Queue.item_ttl(class: 'UniqueInQueueWithTtl')
-    end
-  end
-
-  describe '.lock_after_execution_period' do
-    it 'is 0 for non-unique job' do
-      assert_equal 0, Resque::UniqueInQueue::Queue.lock_after_execution_period(class: 'FakeJob')
-    end
-
-    it 'is 0 for invalid job class' do
-      assert_equal 0, Resque::UniqueInQueue::Queue.lock_after_execution_period(class: 'InvalidJob')
-    end
-
-    it 'is 0 for unique job' do
-      assert_equal 0, Resque::UniqueInQueue::Queue.lock_after_execution_period(class: 'FakeUniqueInQueue')
-    end
-
-    it 'is job lock period' do
-      assert_equal 150, UniqueInQueueWithLock.lock_after_execution_period
-      assert_equal 150, Resque::UniqueInQueue::Queue.lock_after_execution_period(class: 'UniqueInQueueWithLock')
-    end
-  end
 end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class QueueTest < MiniTest::Spec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,8 +9,6 @@ require 'fake_jobs'
 require 'fakeredis/minitest'
 
 begin
-  require 'minitest/focus'
-  # require 'pry'
   require 'byebug'
 rescue LoadError
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,9 @@ require 'fake_jobs'
 require 'fakeredis/minitest'
 
 begin
-  require 'pry-byebug'
+  require 'minitest/focus'
+  # require 'pry'
+  require 'byebug'
 rescue LoadError
-  # ignore
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['SIMPLE_COV']
   require 'simplecov'
   SimpleCov.start


### PR DESCRIPTION
Use sets rather than the global redis key namespace #2

## Why is this change necessary?
Searching the entire namespace to remove keys is simply too expensive.

## How does it address the issue?
By using sets to speed things up.

Basically, instead of having every information we need in the key, we'll add some of it to the set.

### Before
```
r-uiq:queue:unique_with_ttl:job:* => 1
```

### Now
```
r-uiq:queue:unique_with_ttl:job => [JOB1, JOB2]
```


## What side effects does this change have?
Old keys will no longer be used. Perhaps we'll have to update the gem version?